### PR TITLE
Replace TODO contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ keybase is open, it is ready to store and maintain keys. Each key is assigned to
 and can be inserted using the `Put` function:
 
 ```go
-_ = kb.Put(context.TODO(), "namespace", "key")
+_ = kb.Put(context.Background(), "namespace", "key")
 ```
 
 Once the key is stored, various functions can be used to query key and namespace information,
@@ -30,7 +30,7 @@ namespace:
 ```go
 active := true
 unique := true
-keys, err := kb.GetKeys(context.TODO(), "namespace", active, unique)
+keys, err := kb.GetKeys(context.Background(), "namespace", active, unique)
 ```
 
 By setting `active` and `unique` to `true`, the slice will include each active key once. Otherwise,
@@ -39,7 +39,7 @@ submitted multiple times and queried within the TTL duration. Over time, as the 
 they can be removed using the `PruneEntries` function:
 
 ```go
-_ = kb.PruneEntries(context.TODO())
+_ = kb.PruneEntries(context.Background())
 ```
 
 This will remove the stale keys and reduce the amount of storage required by memory or 

--- a/keybase_test.go
+++ b/keybase_test.go
@@ -32,26 +32,26 @@ import (
 )
 
 func TestOpenClose(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(0))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(0))
 	defer cancel()
 	keybase, err := Open(ctx)
 	assert.Nil(t, keybase)
 	assert.Error(t, err)
-	keybase, err = Open(context.TODO())
+	keybase, err = Open(context.Background())
 	assert.NotNil(t, keybase)
 	assert.NoError(t, err)
 	defer keybase.Close()
 }
 
 func TestPut(t *testing.T) {
-	keybase, err := Open(context.TODO())
+	keybase, err := Open(context.Background())
 	assert.NoError(t, err)
 	defer keybase.Close()
 
-	err = keybase.Put(context.TODO(), "namespace", "keyvalue")
+	err = keybase.Put(context.Background(), "namespace", "keyvalue")
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(0))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(0))
 	defer cancel()
 	err = keybase.Put(ctx, "namespace", "keyvalue")
 	assert.Error(t, err)
@@ -64,31 +64,31 @@ func TestKey(t *testing.T) {
 		"key0", "key0", "key1",
 	}
 	pattern := "key*"
-	keybase, err := Open(context.TODO())
+	keybase, err := Open(context.Background())
 	assert.NoError(t, err)
 	defer keybase.Close()
 
 	for _, key := range keys {
-		err = keybase.Put(context.TODO(), namespace, key)
+		err = keybase.Put(context.Background(), namespace, key)
 		assert.NoError(t, err)
 	}
 
-	err = keybase.Put(context.TODO(), "othernamespace", "key0")
+	err = keybase.Put(context.Background(), "othernamespace", "key0")
 	assert.NoError(t, err)
 
-	matchedKeys, err := keybase.MatchKey(context.TODO(), namespace, pattern, true, false)
+	matchedKeys, err := keybase.MatchKey(context.Background(), namespace, pattern, true, false)
 	assert.Len(t, matchedKeys, 3)
 	assert.NoError(t, err)
 
-	matchedKeys, err = keybase.MatchKey(context.TODO(), namespace, pattern, true, true)
+	matchedKeys, err = keybase.MatchKey(context.Background(), namespace, pattern, true, true)
 	assert.Len(t, matchedKeys, 2)
 	assert.NoError(t, err)
 
-	count, err := keybase.CountKey(context.TODO(), namespace, keys[0], true)
+	count, err := keybase.CountKey(context.Background(), namespace, keys[0], true)
 	assert.Equal(t, 2, count)
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(0))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(0))
 	defer cancel()
 	_, err = keybase.MatchKey(ctx, namespace, pattern, true, false)
 	assert.Error(t, err)
@@ -102,35 +102,35 @@ func TestKeys(t *testing.T) {
 	keys := []string{
 		"key0", "key0", "key1",
 	}
-	keybase, err := Open(context.TODO())
+	keybase, err := Open(context.Background())
 	assert.NoError(t, err)
 	defer keybase.Close()
 
 	for _, key := range keys {
-		err = keybase.Put(context.TODO(), namespace, key)
+		err = keybase.Put(context.Background(), namespace, key)
 		assert.NoError(t, err)
 	}
 
-	err = keybase.Put(context.TODO(), "othernamespace", "key0")
+	err = keybase.Put(context.Background(), "othernamespace", "key0")
 	assert.NoError(t, err)
 
-	namespaceKeys, err := keybase.GetKeys(context.TODO(), namespace, true, false)
+	namespaceKeys, err := keybase.GetKeys(context.Background(), namespace, true, false)
 	assert.Len(t, namespaceKeys, 3)
 	assert.NoError(t, err)
 
-	namespaceKeys, err = keybase.GetKeys(context.TODO(), namespace, true, true)
+	namespaceKeys, err = keybase.GetKeys(context.Background(), namespace, true, true)
 	assert.Len(t, namespaceKeys, 2)
 	assert.NoError(t, err)
 
-	count, err := keybase.CountKeys(context.TODO(), namespace, true, false)
+	count, err := keybase.CountKeys(context.Background(), namespace, true, false)
 	assert.Equal(t, 3, count)
 	assert.NoError(t, err)
 
-	count, err = keybase.CountKeys(context.TODO(), namespace, true, true)
+	count, err = keybase.CountKeys(context.Background(), namespace, true, true)
 	assert.Equal(t, 2, count)
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(0))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(0))
 	defer cancel()
 	_, err = keybase.GetKeys(ctx, namespace, true, false)
 	assert.Error(t, err)
@@ -139,29 +139,29 @@ func TestKeys(t *testing.T) {
 }
 
 func TestNamespaces(t *testing.T) {
-	keybase, err := Open(context.TODO())
+	keybase, err := Open(context.Background())
 	assert.NoError(t, err)
 	defer keybase.Close()
 
 	for namespaceIndex := 0; namespaceIndex < 3; namespaceIndex++ {
 		namespace := fmt.Sprintf("namespace%d", namespaceIndex)
-		err = keybase.Put(context.TODO(), namespace, "key0")
+		err = keybase.Put(context.Background(), namespace, "key0")
 		assert.NoError(t, err)
-		err = keybase.Put(context.TODO(), namespace, "key0")
+		err = keybase.Put(context.Background(), namespace, "key0")
 		assert.NoError(t, err)
-		err = keybase.Put(context.TODO(), namespace, "key1")
+		err = keybase.Put(context.Background(), namespace, "key1")
 		assert.NoError(t, err)
 	}
 
-	namespaces, err := keybase.GetNamespaces(context.TODO(), true)
+	namespaces, err := keybase.GetNamespaces(context.Background(), true)
 	assert.Len(t, namespaces, 3)
 	assert.NoError(t, err)
 
-	count, err := keybase.CountNamespaces(context.TODO(), true)
+	count, err := keybase.CountNamespaces(context.Background(), true)
 	assert.Equal(t, 3, count)
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(0))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(0))
 	defer cancel()
 	_, err = keybase.GetNamespaces(ctx, true)
 	assert.Error(t, err)
@@ -171,56 +171,56 @@ func TestNamespaces(t *testing.T) {
 
 // TestEntries tests CountEntries, PruneEntries, and ClearEntries
 func TestEntries(t *testing.T) {
-	keybase, err := Open(context.TODO(), WithTTL(time.Millisecond*50))
+	keybase, err := Open(context.Background(), WithTTL(time.Millisecond*50))
 	assert.NoError(t, err)
 	defer keybase.Close()
 
 	for namespaceIndex := 0; namespaceIndex < 3; namespaceIndex++ {
 		namespace := fmt.Sprintf("namespace%d", namespaceIndex)
-		err = keybase.Put(context.TODO(), namespace, "key0")
+		err = keybase.Put(context.Background(), namespace, "key0")
 		assert.NoError(t, err)
-		err = keybase.Put(context.TODO(), namespace, "key0")
+		err = keybase.Put(context.Background(), namespace, "key0")
 		assert.NoError(t, err)
-		err = keybase.Put(context.TODO(), namespace, "key1")
+		err = keybase.Put(context.Background(), namespace, "key1")
 		assert.NoError(t, err)
 	}
 
-	count, err := keybase.CountEntries(context.TODO(), true, false)
+	count, err := keybase.CountEntries(context.Background(), true, false)
 	assert.Equal(t, 9, count)
 	assert.NoError(t, err)
 
-	count, err = keybase.CountEntries(context.TODO(), true, true)
+	count, err = keybase.CountEntries(context.Background(), true, true)
 	assert.Equal(t, 6, count)
 	assert.NoError(t, err)
 
 	time.Sleep(time.Millisecond * 50)
 
-	count, err = keybase.CountEntries(context.TODO(), false, false)
+	count, err = keybase.CountEntries(context.Background(), false, false)
 	assert.Equal(t, 9, count)
 	assert.NoError(t, err)
 
-	err = keybase.PruneEntries(context.TODO())
+	err = keybase.PruneEntries(context.Background())
 	assert.NoError(t, err)
 
-	count, err = keybase.CountEntries(context.TODO(), false, false)
+	count, err = keybase.CountEntries(context.Background(), false, false)
 	assert.Zero(t, count)
 	assert.NoError(t, err)
 
-	err = keybase.Put(context.TODO(), "namespace", "key")
+	err = keybase.Put(context.Background(), "namespace", "key")
 	assert.NoError(t, err)
 
-	count, err = keybase.CountEntries(context.TODO(), false, false)
+	count, err = keybase.CountEntries(context.Background(), false, false)
 	assert.Equal(t, 1, count)
 	assert.NoError(t, err)
 
-	err = keybase.ClearEntries(context.TODO())
+	err = keybase.ClearEntries(context.Background())
 	assert.NoError(t, err)
 
-	count, err = keybase.CountEntries(context.TODO(), false, false)
+	count, err = keybase.CountEntries(context.Background(), false, false)
 	assert.Zero(t, count)
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(0))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(0))
 	defer cancel()
 	_, err = keybase.CountEntries(ctx, true, true)
 	assert.Error(t, err)
@@ -235,7 +235,7 @@ func TestStorage(t *testing.T) {
 	storageDirectory, _ := os.MkdirTemp(os.TempDir(), "keybase-*")
 	storagePath := path.Join(storageDirectory, "keybase.db")
 	initAndStore := func(ctx context.Context) {
-		keybase, err := Open(context.TODO(), WithStorage(storagePath))
+		keybase, err := Open(context.Background(), WithStorage(storagePath))
 		assert.NoError(t, err)
 		assert.NotNil(t, keybase)
 		defer keybase.Close()
@@ -247,7 +247,7 @@ func TestStorage(t *testing.T) {
 		}
 	}
 	loadAndCount := func(ctx context.Context) int {
-		keybase, err := Open(context.TODO(), WithStorage(storagePath))
+		keybase, err := Open(context.Background(), WithStorage(storagePath))
 		assert.NoError(t, err)
 		assert.NotNil(t, keybase)
 		defer keybase.Close()
@@ -256,10 +256,10 @@ func TestStorage(t *testing.T) {
 		return count
 	}
 
-	_, err := Open(context.TODO(), WithStorage(storageDirectory))
+	_, err := Open(context.Background(), WithStorage(storageDirectory))
 	assert.Error(t, err)
 
-	initAndStore(context.TODO())
-	count := loadAndCount(context.TODO())
+	initAndStore(context.Background())
+	count := loadAndCount(context.Background())
 	assert.Equal(t, 9, count)
 }

--- a/query_test.go
+++ b/query_test.go
@@ -54,11 +54,11 @@ func TestNewTableQuery(t *testing.T) {
 	tx := newCreateTableQuery()
 
 	mock.ExpectExec(regexp.QuoteMeta(tx.query)).WillReturnError(errors.New("some error"))
-	err := tx.queryExec(context.TODO(), db)
+	err := tx.queryExec(context.Background(), db)
 	assert.Error(t, err)
 
 	mock.ExpectExec(regexp.QuoteMeta(tx.query)).WillReturnResult(sqlmock.NewResult(1, 1))
-	err = tx.queryExec(context.TODO(), db)
+	err = tx.queryExec(context.Background(), db)
 	assert.NoError(t, err)
 }
 
@@ -67,11 +67,11 @@ func TestNewPutQuery(t *testing.T) {
 	tx := newPutQuery(namespace, key, timestamp)
 
 	mock.ExpectExec(regexp.QuoteMeta(tx.query)).WillReturnError(errors.New("some error"))
-	err := tx.queryExec(context.TODO(), db)
+	err := tx.queryExec(context.Background(), db)
 	assert.Error(t, err)
 
 	mock.ExpectExec(regexp.QuoteMeta(tx.query)).WillReturnResult(sqlmock.NewResult(1, 1))
-	err = tx.queryExec(context.TODO(), db)
+	err = tx.queryExec(context.Background(), db)
 	assert.NoError(t, err)
 }
 
@@ -176,11 +176,11 @@ func TestNewPruneEntriesQuery(t *testing.T) {
 	tx := newPruneEntriesQuery(timestamp)
 
 	mock.ExpectExec(regexp.QuoteMeta(tx.query)).WillReturnError(errors.New("some error"))
-	err := tx.queryExec(context.TODO(), db)
+	err := tx.queryExec(context.Background(), db)
 	assert.Error(t, err)
 
 	mock.ExpectExec(regexp.QuoteMeta(tx.query)).WillReturnResult(sqlmock.NewResult(1, 1))
-	err = tx.queryExec(context.TODO(), db)
+	err = tx.queryExec(context.Background(), db)
 	assert.NoError(t, err)
 }
 
@@ -189,11 +189,11 @@ func TestNewClearEntriesQuery(t *testing.T) {
 	tx := newClearEntriesQuery()
 
 	mock.ExpectExec(regexp.QuoteMeta(tx.query)).WillReturnError(errors.New("some error"))
-	err := tx.queryExec(context.TODO(), db)
+	err := tx.queryExec(context.Background(), db)
 	assert.Error(t, err)
 
 	mock.ExpectExec(regexp.QuoteMeta(tx.query)).WillReturnResult(sqlmock.NewResult(1, 1))
-	err = tx.queryExec(context.TODO(), db)
+	err = tx.queryExec(context.Background(), db)
 	assert.NoError(t, err)
 }
 
@@ -202,15 +202,15 @@ func TestQueryCount(t *testing.T) {
 	tx := &dbtx{query: ""}
 
 	mock.ExpectQuery(tx.query).WillReturnError(errors.New("some error"))
-	_, err := tx.queryCount(context.TODO(), db)
+	_, err := tx.queryCount(context.Background(), db)
 	assert.Error(t, err)
 
 	mock.ExpectQuery(tx.query).WillReturnRows(sqlmock.NewRows([]string{"col0"}).AddRow("col"))
-	_, err = tx.queryCount(context.TODO(), db)
+	_, err = tx.queryCount(context.Background(), db)
 	assert.Error(t, err)
 
 	mock.ExpectQuery(tx.query).WillReturnRows(sqlmock.NewRows([]string{"col0"}).AddRow(1))
-	_, err = tx.queryCount(context.TODO(), db)
+	_, err = tx.queryCount(context.Background(), db)
 	assert.NoError(t, err)
 }
 
@@ -219,14 +219,14 @@ func TestQueryValues(t *testing.T) {
 	tx := &dbtx{query: ""}
 
 	mock.ExpectQuery(tx.query).WillReturnError(errors.New("some error"))
-	_, err := tx.queryValues(context.TODO(), db)
+	_, err := tx.queryValues(context.Background(), db)
 	assert.Error(t, err)
 
 	mock.ExpectQuery(tx.query).WillReturnRows(sqlmock.NewRows([]string{"col0", "col1"}).AddRow("col0", "col1"))
-	_, err = tx.queryValues(context.TODO(), db)
+	_, err = tx.queryValues(context.Background(), db)
 	assert.Error(t, err)
 
 	mock.ExpectQuery(tx.query).WillReturnRows(sqlmock.NewRows([]string{"col0"}).AddRow("value"))
-	_, err = tx.queryValues(context.TODO(), db)
+	_, err = tx.queryValues(context.Background(), db)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
All occurrences of `context.TODO()` have been replaced with `context.Background()`.